### PR TITLE
Feature/support empty variables

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -33,13 +33,13 @@ module.exports = function (data) {
                     var importedId = specifier.imported.name
                     var localId = specifier.local.name;
 
-                    if(!config[importedId]) {
+                    if(typeof config[importedId] === 'undefined') {
                       throw path.get('specifiers')[idx].buildCodeFrameError('Try to import dotenv variable "' + importedId + '" which is not defined in any .env files.')
                     }
 
                     var binding = path.scope.getBinding(localId);
                     binding.referencePaths.forEach(function(refPath){
-                      if (config[importedId]) {
+                      if (typeof config[importedId] !== 'undefined') {
                         refPath.replaceWith(t.valueToNode(config[importedId]))
                       }
                     });


### PR DESCRIPTION
### What problem does this PR solve?
When setting an empty variable or falsy values, e.g `MY_ENV_VAR=` or `MY_ENV_NUMBER=0`, it throws an error that makes sense only for undefined variables `Try to import dotenv variable  MY_ENV_VAR which is not defined in any .env files.`

### How does this PR solve it?
Don't compare undefined/defined values to be falsy/truthy, but compare its type to `undefined`